### PR TITLE
Delete duplicated description

### DIFF
--- a/fullstopschecker.py
+++ b/fullstopschecker.py
@@ -412,15 +412,60 @@ def editDesc(itemPage, key, description, newDescription, count, editMode, editGr
             for row in reader:
                 print(row)
                 if description in row[1]:
-                    print(description)
-                    print("Debería ser eliminada [elaborar mecanismo]")
+                    try:
+                        # Check the editing mode
+                        if editMode is True:
+                            # Information string to print in the cli
+                            info = u"{}{}{}{}\t{}\tfull stop removed automatically".format(
+                                c.Fore.WHITE, c.Style.BRIGHT, item, cR, lang[key]
+                            )
+                            print(info)
+
+                            # Information dictionary to make the log (without Colorama)
+                            info = {
+                                "time": timestamp,
+                                "item": item,
+                                "key": key + "-desc",
+                                "msg": "full stop removed automatically"
+                            }
+
+                            # Applying the edition
+                            itemPage.editDescriptions(replacement, summary=summary["removed"])
+
+                            # Checking and updating the CSV logfile
+                            log.check(info, logName, mode="csv")
+
+                        else:
+                            info = u"{}{}{}{}\t{}\tfull stop removed automatically(non edit made, test mode)".format(
+                                c.Fore.WHITE, c.Style.BRIGHT, item, cR, lang[key]
+                            )
+                            print(info)
+
+                            info = {
+                                "time": timestamp,
+                                "item": item,
+                                "key": key + "-desc",
+                                "msg": "full stop removed automatically (non edit made, test mode)"
+                            }
+
+                            log.check(info, logName, mode="csv")
+
+                    except Exception as e:
+                        print(e)
+
+                        info = {
+                            "time": timestamp,
+                            "item": item,
+                            "key": key + "-desc",
+                            "msg": e
+                        }
+
+                        log.check(info, logName, mode="csv")
+
                 elif description not in row[1]:
                     writer = csv.writer(duplicatedFile, delimiter=",")
                     writer.writerow([dataIndex, description])
-                    print("Descripción añadida")
-
-                else:
-                    print("Algo fue mal")
+                    print("Duplicated description added to the file.")
 
     # Skip description
     elif answers["actions"] == "Skip description":

--- a/fullstopschecker.py
+++ b/fullstopschecker.py
@@ -23,10 +23,9 @@ Each action is checked and registered in a CSV log in /logs and, at the end, it 
 a HTML file that works as CSV viewer (the same if a CSV checklist has been created).
 '''
 import colorama as c
+import csv
 import datetime
 import inquirer
-import numpy as np
-import pandas as pd
 import re
 import sys
 
@@ -356,20 +355,24 @@ def editDesc(itemPage, key, description, newDescription, count, editMode, editGr
     # Remove if the script find the same description again
     elif answers["actions"] == "Remove duplicates automatically":
         print("Duplicated. It should be removed.")
-        
+
         global dataIndex
         dataIndex += 1
 
-        rawDuplicated = {
-                "id": dataIndex,
-                "description": description
-        }
+        with open(duplicated, "r+") as duplicatedFile:
+            reader = csv.reader(duplicatedFile, delimiter=",")
+            for row in reader:
+                print(row)
+                if description in row[1]:
+                    print(description)
+                    print("Debería ser eliminada [elaborar mecanismo]")
+                elif description not in row[1]:
+                    writer = csv.writer(duplicatedFile, delimiter=",")
+                    writer.writerow([dataIndex, description])
+                    print("Descripción añadida")
 
-        dataFrame = pd.DataFrame(rawDuplicated, columns=["description"], index=[dataIndex])
-
-        print(dataFrame)
-
-        dataFrame.to_csv(duplicated, mode="a")
+                else:
+                    print("Algo fue mal")
 
     # Skip description
     elif answers["actions"] == "Skip description":

--- a/fullstopschecker.py
+++ b/fullstopschecker.py
@@ -402,16 +402,17 @@ def editDesc(itemPage, key, description, newDescription, count, editMode, editGr
 
     # Remove if the script find the same description again
     elif answers["actions"] == "Remove duplicates automatically":
-        print("Duplicated. It should be removed.")
-
         global dataIndex
         dataIndex += 1
 
         with open(duplicated, "r+") as duplicatedFile:
             reader = csv.reader(duplicatedFile, delimiter=",")
             for row in reader:
-                print(row)
-                if description in row[1]:
+                if description not in row[1]:
+                    writer = csv.writer(duplicatedFile, delimiter=",")
+                    writer.writerow([dataIndex, description])
+                    print("Duplicated description added to the file.")
+
                     try:
                         # Check the editing mode
                         if editMode is True:
@@ -461,11 +462,6 @@ def editDesc(itemPage, key, description, newDescription, count, editMode, editGr
                         }
 
                         log.check(info, logName, mode="csv")
-
-                elif description not in row[1]:
-                    writer = csv.writer(duplicatedFile, delimiter=",")
-                    writer.writerow([dataIndex, description])
-                    print("Duplicated description added to the file.")
 
     # Skip description
     elif answers["actions"] == "Skip description":

--- a/fullstopschecker.py
+++ b/fullstopschecker.py
@@ -187,9 +187,57 @@ def editDesc(itemPage, key, description, newDescription, count, editMode, editGr
 
     # Item identifier formatted
     item = str(itemPage).lstrip("[[wikidata:").rstrip("]]")
-    
+
     if description in duplicated:
-        print("Descripción duplicada: eliminada correctamente.")
+        try:
+            # Check the editing mode
+            if editMode is True:
+                # Information string to print in the cli
+                info = u"{}{}{}{}\t{}\tfull stop removed automatically".format(
+                    c.Fore.WHITE, c.Style.BRIGHT, item, cR, lang[key]
+                )
+                print(info)
+
+                # Information dictionary to make the log (without Colorama)
+                info = {
+                    "time": timestamp,
+                    "item": item,
+                    "key": key + "-desc",
+                    "msg": "full stop removed automatically"
+                }
+
+                # Applying the edition
+                itemPage.editDescriptions(replacement, summary=summary["removed"])
+
+                # Checking and updating the CSV logfile
+                log.check(info, logName, mode="csv")
+
+            else:
+                info = u"{}{}{}{}\t{}\tfull stop removed automatically(non edit made, test mode)".format(
+                    c.Fore.WHITE, c.Style.BRIGHT, item, cR, lang[key]
+                )
+                print(info)
+
+                info = {
+                    "time": timestamp,
+                    "item": item,
+                    "key": key + "-desc",
+                    "msg": "full stop removed automatically (non edit made, test mode)"
+                }
+
+                log.check(info, logName, mode="csv")
+
+        except Exception as e:
+            print(e)
+
+            info = {
+                "time": timestamp,
+                "item": item,
+                "key": key + "-desc",
+                "msg": e
+            }
+
+            log.check(info, logName, mode="csv")
 
     # Ask for the correct action
     questions = [
@@ -198,7 +246,7 @@ def editDesc(itemPage, key, description, newDescription, count, editMode, editGr
             choices=['Remove full stop', 'Add description to checklist', 'Edit description', 'Remove duplicates automatically', 'Skip description', 'Quit'],
         ),
     ]
-    
+
     answers = inquirer.prompt(questions)
 
     # Remove full stop
@@ -318,7 +366,7 @@ def editDesc(itemPage, key, description, newDescription, count, editMode, editGr
                             "key": key + "-desc",
                             "msg": "full stop removed and other errors fixed (test mode)"
                         }
-                        
+
                         log.check(info, logName, mode="csv")
 
                 except Exception as e:


### PR DESCRIPTION
This PR is part of #10 and it adds the system to:

- Change from `pandas` to native csv module.
- Save a description in the CSV file.
- Delete the description when the script finds one.
- Delete a description that already exists in the CSV file.