### PR TITLE
removeDuplicated() to remove duplicated descriptions

### DIFF
--- a/fullstopschecker.py
+++ b/fullstopschecker.py
@@ -134,7 +134,6 @@ def setLogName(editMode):
 
 
 def removeDuplicated(item, key, description, newDescription, count, editMode, editGroup, logName):
-    print("Checking if it is duplicated...")
     if description in duplicated:
         try:
             # Check the editing mode
@@ -160,7 +159,7 @@ def removeDuplicated(item, key, description, newDescription, count, editMode, ed
                 log.check(info, logName, mode="csv")
 
             else:
-                info = u"{}{}{}{}\t{}\tfull stop removed automatically(non edit made, test mode)".format(
+                info = u"{}{}{}{}\t{}\tfull stop removed automatically (non edit made, test mode)".format(
                     c.Fore.WHITE, c.Style.BRIGHT, item, cR, lang[key]
                 )
                 print(info)


### PR DESCRIPTION
The purpose of this branch was to fix #15, but after make this changes and some tests in my local machine I discovered that this errors only happens in PAWS. So this PR only clean the code, moving all the code dedicated to remove the duplicated descriptions to its own function.

#15 still open until I discovered the reason of this behavior in PAWS.